### PR TITLE
Add split methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,19 +1,22 @@
-extern crate num;
-
 use std::default::Default;
 use std::fmt;
 use std::time::{Duration, Instant};
 
 #[derive(Clone, Copy)]
 pub struct Stopwatch {
+	/// The time the stopwatch was started last, if ever.
 	start_time: Option<Instant>,
+	/// The time the stopwatch was split last, if ever.
+	split_time: Option<Instant>,
+	/// The time elapsed while the stopwatch was running (between start() and stop()).
 	elapsed: Duration,
 }
 
 impl Default for Stopwatch {
-	fn default () -> Stopwatch {
+	fn default() -> Stopwatch {
 		Stopwatch {
 			start_time: None,
+			split_time: None,
 			elapsed: Duration::from_secs(0),
 		}
 	}
@@ -26,48 +29,93 @@ impl fmt::Display for Stopwatch {
 }
 
 impl Stopwatch {
+	/// Returns a new stopwatch.
 	pub fn new() -> Stopwatch {
 		let sw: Stopwatch = Default::default();
 		return sw;
 	}
+
+	/// Returns a new stopwatch which will immediately be started.
 	pub fn start_new() -> Stopwatch {
 		let mut sw = Stopwatch::new();
 		sw.start();
 		return sw;
 	}
 
+	/// Starts the stopwatch.
 	pub fn start(&mut self) {
 		self.start_time = Some(Instant::now());
 	}
+
+	/// Stops the stopwatch.
 	pub fn stop(&mut self) {
 		self.elapsed = self.elapsed();
 		self.start_time = None;
+		self.split_time = None;
 	}
+
+	/// Resets all counters and stops the stopwatch.
 	pub fn reset(&mut self) {
 		self.elapsed = Duration::from_secs(0);
 		self.start_time = None;
+		self.split_time = None;
 	}
+
+	/// Resets and starts the stopwatch again.
 	pub fn restart(&mut self) {
 		self.reset();
 		self.start();
 	}
 
+	/// Returns whether the stopwatch is running.
 	pub fn is_running(&self) -> bool {
 		return self.start_time.is_some();
 	}
 
+	/// Returns the elapsed time since the start of the stopwatch.
 	pub fn elapsed(&self) -> Duration {
 		match self.start_time {
+			// stopwatch is running
 			Some(t1) => {
 				return t1.elapsed() + self.elapsed;
-			},
+			}
+			// stopwatch is not running
 			None => {
 				return self.elapsed;
-			},
+			}
 		}
 	}
+
+	/// Returns the elapsed time since the start of the stopwatch in milliseconds.
 	pub fn elapsed_ms(&self) -> i64 {
 		let dur = self.elapsed();
 		return (dur.as_secs() * 1000 + (dur.subsec_nanos() / 1000000) as u64) as i64;
+	}
+
+	/// Returns the elapsed time since last split or start/restart.
+	///
+	/// If the stopwatch is in stopped state this will always return a zero Duration.
+	pub fn elapsed_split(&mut self) -> Duration {
+		match self.start_time {
+			// stopwatch is running
+			Some(start) => {
+				let res = match self.split_time {
+					Some(split) => split.elapsed(),
+					None => start.elapsed(),
+				};
+				self.split_time = Some(Instant::now());
+				res
+			}
+			// stopwatch is not running
+			None => Duration::from_secs(0),
+		}
+	}
+
+	/// Returns the elapsed time since last split or start/restart in milliseconds.
+	///
+	/// If the stopwatch is in stopped state this will always return zero.
+	pub fn elapsed_split_ms(&mut self) -> i64 {
+		let dur = self.elapsed_split();
+		return (dur.as_secs() * 1000 + (dur.subsec_nanos() / 1_000_000) as u64) as i64;
 	}
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -95,6 +95,56 @@ fn reset() {
 	assert_eq!(sw.elapsed_ms(), 0);
 }
 
+#[test]
+fn split_on_started_watch() {
+	let mut sw = Stopwatch::start_new();
+	sleep_ms(SLEEP_MS);
+	assert_split_near(&mut sw, SLEEP_MS);
+	sleep_ms(SLEEP_MS);
+	assert_split_near(&mut sw, SLEEP_MS);
+
+	assert_sw_near(sw, 2 * SLEEP_MS);
+}
+
+#[test]
+fn split_on_resumed_watch() {
+	let mut sw = Stopwatch::new();
+	sleep_ms(SLEEP_MS);
+	assert_split_near(&mut sw, 0);
+	sleep_ms(SLEEP_MS);
+	assert_split_near(&mut sw, 0);
+	sw.start();
+	sleep_ms(SLEEP_MS);
+	assert_split_near(&mut sw, SLEEP_MS);
+	sleep_ms(SLEEP_MS);
+	assert_split_near(&mut sw, SLEEP_MS);
+	sw.stop();
+	sleep_ms(SLEEP_MS);
+	assert_split_near(&mut sw, 0);
+
+	assert_sw_near(sw, 2 * SLEEP_MS);
+}
+
+#[test]
+fn split_after_reset() {
+	let mut sw = Stopwatch::start_new();
+	sleep_ms(SLEEP_MS);
+	assert_split_near(&mut sw, SLEEP_MS);
+	sw.reset();
+	sleep_ms(SLEEP_MS);
+	assert_split_near(&mut sw, 0);
+}
+
+#[test]
+fn split_after_restart() {
+	let mut sw = Stopwatch::start_new();
+	sleep_ms(SLEEP_MS);
+	assert_split_near(&mut sw, SLEEP_MS);
+	sw.restart();
+	sleep_ms(SLEEP_MS);
+	assert_split_near(&mut sw, SLEEP_MS);
+}
+
 
 
 /////////////// helpers
@@ -114,4 +164,9 @@ fn assert_near(x: i64, y: i64, tolerance: i64) {
 fn assert_sw_near(sw: Stopwatch, elapsed: i64) {
 	let tolerance_value = (TOLERANCE_PERCENTAGE * elapsed as f64) as i64;
 	assert_near(elapsed, sw.elapsed_ms(), tolerance_value);
+}
+
+fn assert_split_near(sw: &mut Stopwatch, elapsed: i64) {
+	let tolerance_value = (TOLERANCE_PERCENTAGE * elapsed as f64) as i64;
+	assert_near(elapsed, sw.elapsed_split_ms(), tolerance_value);
 }


### PR DESCRIPTION
I think this should be the implementation for the feature request in issue #12.

I also added some tests and doc comments to existing and new methods. The usage is as follows:

```rust
let mut sw = Stopwatch::start_new();
// --> do something for three seconds
sw.elapsed_split_ms(); // should return ~3000
// --> do some more for two seconds
sw.elapsed_split_ms(); // should return ~2000
sw.elapsed_ms(); //should return ~5000
```
Maybe this example could also be added to the doc comments.

I'm not sure with the name of the methods, I just used _split_ because the button on the webpage I mentioned in #12 was labeled _Split_.

What do you think? Please tell me if anything is wrong. This is my first real pull request to an existing external project.