### PR TITLE
More time-tracking methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /Cargo.lock
 /doc
+.idea

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,8 +87,6 @@ impl Stopwatch {
 	}
 
 	/// Returns elapsed time since the start of stopwatch in nanoseconds
-	///
-	/// * `return -> i64`: elapsed time in nanoseconds
 	pub fn elapsed_ns(&self) -> u64 {
 		self.elapsed().subsec_nanos() as u64
 	}
@@ -100,17 +98,18 @@ impl Stopwatch {
 	}
 
 	/// Returns elapsed time since the start of stopwatch in seconds
-	///
-	/// * `return -> f64`: return elapsed time in seconds
 	pub fn elapsed_sec(&self) -> f64 {
         ((self.elapsed_ms() * 1000) as f64).round() / 1.0e6
 	}
 
     /// Returns elapsed time since the start of stopwatch in seconds
-	///
-	/// * `return -> f64`: return elapsed time in minutes
     pub fn elapsed_min(&self) -> f64 {
         (self.elapsed_sec() * 1000.0 / 60.0).round() / 1.0e3
+    }
+
+    /// Returns elapsed time since the start of stopwatch in hours
+	pub fn elapsed_hour(&self) -> f64 {
+        (self.elapsed_min() * 1000.0 / 60.0).round() / 1.0e3
     }
 
 	/// Returns the elapsed time since last split or start/restart.
@@ -132,6 +131,13 @@ impl Stopwatch {
 		}
 	}
 
+    /// Returns elapsed time since last split or start/restart in nanoseconds.
+    ///
+	/// If the stopwatch is in stopped state this will always return zero.
+    pub fn elapsed_split_ns(&mut self) -> u64 {
+        self.elapsed_split().subsec_nanos() as u64
+    }
+
 	/// Returns the elapsed time since last split or start/restart in milliseconds.
 	///
 	/// If the stopwatch is in stopped state this will always return zero.
@@ -139,4 +145,25 @@ impl Stopwatch {
 		let dur = self.elapsed_split();
 		return (dur.as_secs() * 1000 + (dur.subsec_nanos() / 1_000_000) as u64) as i64;
 	}
+
+    /// Returns elapsed time since last split or start/restart in seconds
+    ///
+	/// If the stopwatch is in stopped state this will always return zero.
+    pub fn elapsed_split_sec(&mut self) -> f64 {
+        ((self.elapsed_split_ms() * 1000) as f64).round() / 1.0e6
+    }
+
+    /// Returns elapsed time since last split or start/restart in minutes
+    ///
+	/// If the stopwatch is in stopped state this will always return zero.
+    pub fn elapsed_split_min(&mut self) -> f64 {
+        (self.elapsed_split_sec() * 1000.0 / 60.0).round() / 1.0e3
+    }
+
+    /// Returns elapsed time since last split or start/restart in hours
+    ///
+	/// If the stopwatch is in stopped state this will always return zero.
+    pub fn elapsed_split_hour(&mut self) -> f64 {
+        (self.elapsed_split_min() * 1000.0 / 60.0).round() / 1.0e3
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,11 +86,32 @@ impl Stopwatch {
 		}
 	}
 
+	/// Returns elapsed time since the start of stopwatch in nanoseconds
+	///
+	/// * `return -> i64`: elapsed time in nanoseconds
+	pub fn elapsed_ns(&self) -> u64 {
+		self.elapsed().subsec_nanos() as u64
+	}
+
 	/// Returns the elapsed time since the start of the stopwatch in milliseconds.
 	pub fn elapsed_ms(&self) -> i64 {
 		let dur = self.elapsed();
 		return (dur.as_secs() * 1000 + (dur.subsec_nanos() / 1000000) as u64) as i64;
 	}
+
+	/// Returns elapsed time since the start of stopwatch in seconds
+	///
+	/// * `return -> f64`: return elapsed time in seconds
+	pub fn elapsed_sec(&self) -> f64 {
+        ((self.elapsed_ms() * 1000) as f64).round() / 1.0e6
+	}
+
+    /// Returns elapsed time since the start of stopwatch in seconds
+	///
+	/// * `return -> f64`: return elapsed time in minutes
+    pub fn elapsed_min(&self) -> f64 {
+        (self.elapsed_sec() * 1000.0 / 60.0).round() / 1.0e3
+    }
 
 	/// Returns the elapsed time since last split or start/restart.
 	///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,36 @@ impl Default for Stopwatch {
 
 impl fmt::Display for Stopwatch {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		return write!(f, "{}ms", self.elapsed_ms());
+        let mut ms = self.elapsed_ms();
+        let s: i64;
+        let m: i64;
+        let h: i64;
+        let mut buf = String::new();
+
+        s = ms  / 1000;
+        ms = ms % 1000;
+        buf.insert_str(0, &format!("{}ms", ms));
+        if s > 0{
+            buf.insert_str(0, &format!("{}s ", s));
+        } else {
+            return buf.fmt(f);
+        }
+
+        m = s  / 60;
+        if m > 0{
+            buf.insert_str(0, &format!("{}m ", m));
+        } else {
+            return buf.fmt(f);
+        }
+
+        h = m  / 60;
+        if h > 0{
+            buf.insert_str(0, &format!("{}h ", h));
+        } else {
+            return buf.fmt(f);
+        }
+
+        return buf.fmt(f);
 	}
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -31,6 +31,27 @@ fn elapsed_ms() {
 }
 
 #[test]
+fn elapsed_ns(){
+	let sw = Stopwatch::start_new();
+	sleep_ms(2);
+	assert!(sw.elapsed_ns() > 1000000);
+}
+
+#[test]
+fn elapsed_sec(){
+    let sw = Stopwatch::start_new();
+    sleep_ms(2);
+    assert!(sw.elapsed_sec() >= 0.001 || sw.elapsed_sec() <= 0.002);
+}
+
+#[test]
+fn elapsed_min(){
+    let sw = Stopwatch::start_new();
+    sleep_ms(3000);
+    assert!(sw.elapsed_min() >= 0.05 - 0.002 || sw.elapsed_min() <= 0.05 + 0.002);
+}
+
+#[test]
 fn stop() {
 	let mut sw = Stopwatch::start_new();
 	sleep_ms(SLEEP_MS);

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -173,6 +173,23 @@ fn split_after_restart() {
 	assert_split_near(&mut sw, SLEEP_MS);
 }
 
+#[test]
+fn test_display(){
+	let sw = Stopwatch::start_new();
+	sleep_ms(3500);
+	let s = &format!("{}", sw);
+
+    assert!(s == "3s 499ms" || s == "3s 500ms");
+}
+
+#[test]
+fn test_display_low(){
+    let sw = Stopwatch::start_new();
+    sleep_ms(500);
+    let s = &format!("{}", sw);
+
+    assert!(s == "499ms" || s == "500ms");
+}
 
 
 /////////////// helpers

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -52,6 +52,13 @@ fn elapsed_min(){
 }
 
 #[test]
+fn elapsed_hour(){
+	let sw = Stopwatch::start_new();
+	sleep_ms(1000);
+	assert!(sw.elapsed_hour() >= 0.00083 - 0.002 || sw.elapsed_hour() <= 0.00083 + 0.002);
+}
+
+#[test]
 fn stop() {
 	let mut sw = Stopwatch::start_new();
 	sleep_ms(SLEEP_MS);


### PR DESCRIPTION
Hello!

Thanks for the crate :)

I did add some methods for more convenient elapsed time tracking: 
* `in nanoseconds`;
* `in seconds`;
* `in minutes`;
* `in hours`.

Also, it was updated `Display` trait implementation with respect of new methods. It convert milliseconds to more human readable format. For example, if there was elapsed 3500 ms, the next code:

```rust
let sw = Stopwatch::start_new();
println!("{}", sw);
```

will print: `3s 500ms`.

And if there was elapsed, for example, 500 ms it will print `500ms` (if there was spent minutes or even hours this will display them).